### PR TITLE
Moo expects subroutine reference for complex data

### DIFF
--- a/lib/IntelliHome/Workers/Master/StatusListener.pm
+++ b/lib/IntelliHome/Workers/Master/StatusListener.pm
@@ -38,8 +38,12 @@ use IntelliHome::Utils qw(message_expand SEPARATOR);
 extends 'IntelliHome::Workers::Base';
 with("IntelliHome::Workers::Role::Parser");
 
-has 'Output' =>
-    ( is => "rw", default => IntelliHome::Interfaces::Terminal->new );
+has 'Output' => (
+	is      => "rw",
+	default => sub {
+		IntelliHome::Interfaces::Terminal->new();
+	},
+);
 
 sub process {
     my $self = shift;


### PR DESCRIPTION
Alter StatusListener to fix following error:
Invalid default 'IntelliHome::Interfaces::Terminal=HASH(0x195c800)' for
IntelliHome::Workers::Master::StatusListener->Output not a coderef or a
non-ref and could not be converted to a coderef: Not a subroutine
reference at /usr/local/share/perl/5.18.2/Method/Generate/Accessor.pm
line 660.
Compilation failed in require at -e line 1.
BEGIN failed--compilation aborted at -e line 1.
